### PR TITLE
Fix TabError from tab/space mixing in revels_3D.py

### DIFF
--- a/revelsMD/revels_3D.py
+++ b/revelsMD/revels_3D.py
@@ -172,17 +172,16 @@ class Revels3D:
                 On invalid frame selection, unsupported density/kernel combinations,
                 or malformed inputs for rigid/centre options.
             """
-			# --- Validate atom_names ---
-			if isinstance(atom_names, str):
-				# Split string by common delimiters (spaces, commas)
-				atom_list = atom_names.replace(',', ' ').split()
-				if len(atom_list) != len(set(atom_list)):
-					raise ValueError(f"Duplicate atom names detected in input string: {atom_names!r}")
-			elif isinstance(atom_names, list):
-				if len(atom_names) != len(set(atom_names)):
-					raise ValueError(f"Duplicate atom names detected in list: {atom_names!r}")
-			else:
-				raise ValueError("`atom_names` must be a string or list of strings.")
+            # --- Validate atom_names ---
+            if isinstance(atom_names, str):
+                atom_list = atom_names.replace(',', ' ').split()
+                if len(atom_list) != len(set(atom_list)):
+                    raise ValueError(f"Duplicate atom names detected in input string: {atom_names!r}")
+            elif isinstance(atom_names, list):
+                if len(atom_names) != len(set(atom_names)):
+                    raise ValueError(f"Duplicate atom names detected in list: {atom_names!r}")
+            else:
+                raise ValueError("`atom_names` must be a string or list of strings.")
 
             # Validate frame bounds with original modulo semantics
             if start > TS.frames:
@@ -201,7 +200,7 @@ class Revels3D:
             self.to_run = to_run
 
             # Build selection wrapper (keeps original attribute spellings)
-            self.SS = Revels3D.SelectionState(TS, atom_names=atom_names, centre_location=centre_location)
+            self.SS = Revels3D.SelectionState(TS, atom_names=atom_names, centre_location=centre_location, rigid=rigid)
 
             # Choose estimator based on density type and rigid settings
             if self.density_type == "number":
@@ -655,35 +654,30 @@ class Revels3D:
             Axis for polarisation projection (set by GridState when needed).
         """
 
-		def __init__(self, TS: Any, atom_names: Union[str, List[str]], centre_location: Union[bool, int], rigid: bool = False):
-			if isinstance(atom_names, list) and len(atom_names) > 1:
-				self.indistinguishable_set = False
-				self.indices: List[np.ndarray] = []
-				self.charges: List[np.ndarray] = []
-				self.masses: List[np.ndarray] = []
-				for atom in atom_names:
-				    # Uses TS.get_indices (alias exists) for compatibility
-				    self.indices.append(TS.get_indices(atom))
-				    if TS.charge_and_mass is True:
-				        self.charges.append(TS.get_charges(atom))
-				        self.masses.append(TS.get_masses(atom))
-
-				if rigid:
-				    lengths = [len(idx) for idx in self.indices]
-				    if len(set(lengths)) != 1:
-				        raise ValueError(
-				            f"When 'rigid=True', all atom selections must have the same number of indices, "
-				            f"but got lengths {lengths} for atoms {atom_names}."
-				        )
-
-        # --- Centre location validation ---
-        if isinstance(centre_location, (bool, int)):
-            if isinstance(centre_location, int) and centre_location >= len(atom_names):
-                raise ValueError("centre_location index exceeds number of provided atom names.")
-            self.centre_location = centre_location
-        else:
-            raise ValueError("centre_location must be True (COM) or an integer index.")
-
+        def __init__(self, TS: Any, atom_names: Union[str, List[str]], centre_location: Union[bool, int], rigid: bool = False):
+            if isinstance(atom_names, list) and len(atom_names) > 1:
+                self.indistinguishable_set = False
+                self.indices: List[np.ndarray] = []
+                self.charges: List[np.ndarray] = []
+                self.masses: List[np.ndarray] = []
+                for atom in atom_names:
+                    self.indices.append(TS.get_indices(atom))
+                    if TS.charge_and_mass is True:
+                        self.charges.append(TS.get_charges(atom))
+                        self.masses.append(TS.get_masses(atom))
+                if rigid:
+                    lengths = [len(idx) for idx in self.indices]
+                    if len(set(lengths)) != 1:
+                        raise ValueError(
+                            f"When 'rigid=True', all atom selections must have the same number of indices, "
+                            f"but got lengths {lengths} for atoms {atom_names}."
+                        )
+                if isinstance(centre_location, bool) or isinstance(centre_location, int):
+                    if isinstance(centre_location, int) and centre_location >= len(atom_names):
+                        raise ValueError("centre_location index exceeds number of provided atom names.")
+                    self.centre_location = centre_location
+                else:
+                    raise ValueError("centre_location must be True (COM) or an integer index.")
             else:
                 # Single species
                 if isinstance(atom_names, list):


### PR DESCRIPTION
Commit 4065f42 introduced tab characters that caused a `TabError` on import, preventing the module from loading.

This fix:
- Converts tabs to spaces in `make_force_grid` atom_names validation
- Fixes broken control flow in `SelectionState.__init__`
- Passes `rigid` parameter to `SelectionState` (was missing in 4065f42)