### PR TITLE
Fix typo in estimator method name: grids -> grid

### DIFF
--- a/revelsMD/revels_3D.py
+++ b/revelsMD/revels_3D.py
@@ -603,7 +603,7 @@ class Revels3D:
             )
 
         @staticmethod
-        def single_frame_rigid_charge_com_grids(positions, forces, TS, GS, SS, kernel="triangular"):
+        def single_frame_rigid_charge_com_grid(positions, forces, TS, GS, SS, kernel="triangular"):
             """Rigid molecule: charge-weighted density at COM."""
             coms = Revels3D.HelperFunctions.find_coms(positions, TS, GS, SS)
             rigid_forces = Revels3D.HelperFunctions.sum_forces(SS, forces)


### PR DESCRIPTION
## Summary

- Renames `single_frame_rigid_charge_com_grids` to `single_frame_rigid_charge_com_grid`
- Fixes mismatch between method name and the expected name in estimator selection logic
- Without this fix, using `density_type="charge"` with `rigid=True` and `centre_location=True` would raise an `AttributeError`