### PR TITLE
Add package metadata to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,10 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "revelsMD"
-authors = [{name = "Samuel Coles", email = "swc57@bath.ac.uk"}]
+authors = [
+    {name = "Samuel Coles", email = "swc57@bath.ac.uk"},
+    {name = "Benjamin J. Morgan", email = "b.j.morgan@bath.ac.uk"}
+]
 dynamic = ["version", "description"]
 license = {file = "LICENSE"}
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Add missing package metadata for PyPI publication readiness.

## Changes

- `license`: Reference LICENSE file
- `keywords`: molecular-dynamics, radial-distribution-function, density, force-sampling, reduced-variance
- `classifiers`: Development status, audience, license, Python versions (3.11-3.14), topics
- `project.urls`: Homepage and repository links